### PR TITLE
Refactor routes with path params and add Makefile

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,21 @@
+name: Go CI
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+    branches: ["*"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+      - name: Vet
+        run: go vet ./...
+      - name: Build
+        run: go build ./...
+      - name: Test
+        run: go test ./...

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: build test run
+
+build:
+	go vet ./...
+	go build -o anime-server
+
+test:
+	go test ./...
+
+run: build
+	./anime-server

--- a/README.md
+++ b/README.md
@@ -1,2 +1,48 @@
 # miniature-sniffle
-Rest API in Golang
+
+This project provides a small REST API server written in Go 1.22+. It stores data in memory so no external database is required. Routes use the Go 1.22 `"<METHOD> <URI>"` registration syntax.
+
+## Features
+
+* Create anime entries with a unique title.
+* List all anime or fetch a single anime by ID.
+* Add ratings and text reviews to an anime.
+* List reviews for a specific anime.
+
+## Building and Running
+
+``` 
+# build the server
+make build
+
+# run the server on port 8080
+make run
+```
+
+The API will be available at `http://localhost:8080`.
+
+## Running Tests
+
+```
+make test
+```
+
+GitHub Actions are configured to run vet, build and test on each push.
+
+## Example Requests
+
+Create an anime:
+
+```
+curl -X POST http://localhost:8080/animes \
+  -H "Content-Type: application/json" \
+  -d '{"title":"Naruto","creator":"Masashi Kishimoto","genre":"Shonen","year":2002}'
+```
+
+Add a review:
+
+```
+curl -X POST http://localhost:8080/animes/1/reviews \
+  -H "Content-Type: application/json" \
+  -d '{"rating":5,"text":"Great show"}'
+```

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module miniature-sniffle
+
+go 1.23.8

--- a/main.go
+++ b/main.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"sync"
+)
+
+type Review struct {
+	Rating int    `json:"rating"`
+	Text   string `json:"text"`
+}
+
+type Anime struct {
+	ID      int      `json:"id"`
+	Title   string   `json:"title"`
+	Creator string   `json:"creator"`
+	Genre   string   `json:"genre"`
+	Year    int      `json:"year"`
+	Reviews []Review `json:"reviews,omitempty"`
+}
+
+var (
+	mu      sync.Mutex
+	animes  = make(map[int]*Anime)
+	byTitle = make(map[string]int)
+	nextID  = 1
+)
+
+func newServer() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("%s /animes", http.MethodPost), createAnime)
+	mux.HandleFunc(fmt.Sprintf("%s /animes", http.MethodGet), listAnimes)
+	mux.HandleFunc(fmt.Sprintf("%s /animes/{id}", http.MethodGet), getAnime)
+	mux.HandleFunc(fmt.Sprintf("%s /animes/{id}/reviews", http.MethodPost), addReview)
+	mux.HandleFunc(fmt.Sprintf("%s /animes/{id}/reviews", http.MethodGet), listReviews)
+	return mux
+}
+
+func main() {
+	mux := newServer()
+
+	// TODO: add authentication and validation middleware
+
+	log.Println("Server listening on :8080")
+	log.Fatal(http.ListenAndServe(":8080", mux))
+}
+
+func createAnime(w http.ResponseWriter, r *http.Request) {
+	var a Anime
+	if err := json.NewDecoder(r.Body).Decode(&a); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	if a.Title == "" {
+		http.Error(w, "title is required", http.StatusBadRequest)
+		return
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if _, ok := byTitle[a.Title]; ok {
+		http.Error(w, "anime title already exists", http.StatusConflict)
+		return
+	}
+	a.ID = nextID
+	nextID++
+	animes[a.ID] = &a
+	byTitle[a.Title] = a.ID
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(a)
+}
+
+func listAnimes(w http.ResponseWriter, r *http.Request) {
+	mu.Lock()
+	defer mu.Unlock()
+	list := make([]*Anime, 0, len(animes))
+	for _, a := range animes {
+		list = append(list, a)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(list)
+}
+
+func getAnime(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.Atoi(r.PathValue("id"))
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	mu.Lock()
+	a, ok := animes[id]
+	mu.Unlock()
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(a)
+}
+
+func addReview(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.Atoi(r.PathValue("id"))
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	mu.Lock()
+	a, ok := animes[id]
+	mu.Unlock()
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	var rv Review
+	if err := json.NewDecoder(r.Body).Decode(&rv); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	if rv.Rating < 1 || rv.Rating > 5 {
+		http.Error(w, "rating must be between 1 and 5", http.StatusBadRequest)
+		return
+	}
+	mu.Lock()
+	a.Reviews = append(a.Reviews, rv)
+	mu.Unlock()
+
+	w.WriteHeader(http.StatusCreated)
+}
+
+func listReviews(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.Atoi(r.PathValue("id"))
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	mu.Lock()
+	a, ok := animes[id]
+	if !ok {
+		mu.Unlock()
+		http.NotFound(w, r)
+		return
+	}
+	reviews := append([]Review(nil), a.Reviews...)
+	mu.Unlock()
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(reviews)
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func setup() *httptest.Server {
+	mu.Lock()
+	animes = make(map[int]*Anime)
+	byTitle = make(map[string]int)
+	nextID = 1
+	mu.Unlock()
+	return httptest.NewServer(newServer())
+}
+
+func TestCreateAnime(t *testing.T) {
+	ts := setup()
+	defer ts.Close()
+
+	body := `{"title":"Naruto","creator":"Masashi","genre":"Shonen","year":2002}`
+	resp, err := http.Post(ts.URL+"/animes", "application/json", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201 got %d", resp.StatusCode)
+	}
+
+	// duplicate title
+	resp2, err := http.Post(ts.URL+"/animes", "application/json", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("post2: %v", err)
+	}
+	if resp2.StatusCode != http.StatusConflict {
+		t.Fatalf("expected 409 got %d", resp2.StatusCode)
+	}
+}
+
+func TestAddReview(t *testing.T) {
+	ts := setup()
+	defer ts.Close()
+
+	body := `{"title":"Naruto","creator":"Masashi","genre":"Shonen","year":2002}`
+	resp, err := http.Post(ts.URL+"/animes", "application/json", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201 got %d", resp.StatusCode)
+	}
+
+	review := `{"rating":5,"text":"Great"}`
+	resp, err = http.Post(ts.URL+"/animes/1/reviews", "application/json", bytes.NewBufferString(review))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201 got %d", resp.StatusCode)
+	}
+
+	r, err := http.Get(ts.URL + "/animes/1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var a Anime
+	if err := json.NewDecoder(r.Body).Decode(&a); err != nil {
+		t.Fatal(err)
+	}
+	if len(a.Reviews) != 1 {
+		t.Fatalf("expected 1 review got %d", len(a.Reviews))
+	}
+}


### PR DESCRIPTION
## Summary
- refactor server to register routes with formatted strings
- use ServeMux path parameters for anime ID and reviews
- document `make` commands for build/run/test
- add a Makefile for convenience

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6853f3f6dc7883258766e1c115042682